### PR TITLE
Fix build with qt4's moc & boost 1.57

### DIFF
--- a/src/rviz_plugin/ork_object_display.h
+++ b/src/rviz_plugin/ork_object_display.h
@@ -33,7 +33,10 @@
 #include <rviz/message_filter_display.h>
 
 #include <object_recognition_msgs/RecognizedObjectArray.h>
+
+#ifndef Q_MOC_RUN
 #include <object_recognition_ros/object_info_cache.h>
+#endif
 
 namespace object_recognition_ros
 {


### PR DESCRIPTION
This is a common workaround to make sure moc doesn't see preprocessorvariables
it doesn't like in boost...
